### PR TITLE
Upgrading IntelliJ from 2023.3.1 to 2023.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.3.1 to 2023.3.2
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Environment Variable Settings Summary'
 # SemVer format -> https://semver.org
-pluginVersion = 3.2.1
+pluginVersion = 3.2.2
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 3.2.1
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.3.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.3.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 
@@ -24,7 +24,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.3.1
+platformVersion = 2023.3.2
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.3.1 to 2023.3.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661803/IntelliJ-IDEA-2023.3.2-233.13135.103-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.3.2 is out with the following improvements: 
<ul> 
 <li>The IDE no longer erroneously resets namespaces during actions like <em>Apply</em>, <em>Refresh</em>, and others when working with Kubernetes. [<a href="https://youtrack.jetbrains.com/issue/IDEA-339448">IDEA-339448</a>]</li> 
 <li>The branch checkout from the <em>Pull Request</em> pane has been fixed. [<a href="https://youtrack.jetbrains.com/issue/IDEA-339471/">IDEA-339471</a>] </li> 
 <li>The <em>New</em> context menu once again appears correctly on a right-click when the Grails plugin is installed. [<a href="https://youtrack.jetbrains.com/issue/IDEA-340588/New-submenu-doesnt-open-with-Grails-plugin-installed">IDEA-340588</a>]</li> 
 <li>When you work on Linux without a window manager, the main menu is now displayed for all open projects. [<a href="https://youtrack.jetbrains.com/issue/IDEA-337548/No-main-menu-on-simple-linux-with-Xvfb">IDEA-337548</a>]</li> 
 <li>The IDE now accurately provides the <em>Constant values</em> inspection for Stream expressions with nested Optional chains, eliminating the occurrence of false positives. [<a href="https://youtrack.jetbrains.com/issue/IDEA-340683/">IDEA-340683</a>] </li> 
</ul> For more details, please refer to this 
<a href="https://blog.jetbrains.com/idea/2023/12/intellij-idea-2023-3-2/">blog post</a>.
    