### PR TITLE
Upgrading IntelliJ from 2023.3.2 to 2023.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.3.2 to 2023.3.3
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Environment Variable Settings Summary'
 # SemVer format -> https://semver.org
-pluginVersion = 3.2.2
+pluginVersion = 3.2.3
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 3.2.2
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.3.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.3.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 
@@ -24,7 +24,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.3.2
+platformVersion = 2023.3.3
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.3.2 to 2023.3.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661841/IntelliJ-IDEA-2023.3.3-233.14015.106-build-Release-Notes

# What's New?
IntelliJ IDEA 2023.3.3 is out with the following improvements: 
<ul> 
 <li>Submitting GitLab reviews with an empty review message is possible again. [<a href="https://youtrack.jetbrains.com/issue/IDEA-337325/">IDEA-337325</a>]</li> 
 <li>The IDE no longer sends erroneous update notifications for disabled plugins. [<a href="https://youtrack.jetbrains.com/issue/IDEA-273418/IDEA-insists-on-updating-bundled-plugins-even-though-they-are-disabled">IDEA-273418</a>]</li> 
 <li>The first attempt to launch GWT Super Dev Mode after the IDE restarts no longer fails. [<a href="https://youtrack.jetbrains.com/issue/IDEA-283472/Launching-GWT-Super-Dev-Mode-takes-two-attempts-fails-at-first-attempt">IDEA-283472</a>]</li> 
 <li>Marking GitHub pull request files as "reviewed" works as expected again. [<a href="https://youtrack.jetbrains.com/issue/IDEA-338906/GitHub-plugin-Can-no-longer-pull-request-files-mark-as-read">IDEA-338906</a>]</li> 
 <li>Visual guides set to custom values in <em>Settings/Preferences | Editor | Code Style</em> once again appear in the editor correctly. [<a href="https://youtrack.jetbrains.com/issue/IDEA-339976/Cant-change-visual-guides-since-updating-to-2023.3">IDEA-339976</a>]</li> 
</ul> For more details, please refer to this 
<a href="https://blog.jetbrains.com/idea/2024/01/intellij-idea-2023-3-3/">blog post</a>.
    