### PR TITLE
Upgrading IntelliJ from 2024.3.3 to 2024.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.3 to 2024.3.4
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/environment-variable-settin
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 4.2.6
+pluginVersion = 4.2.7
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 243.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.3.3,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2024.3.4,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -33,7 +33,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.3.3
+platformVersion = 2024.3.4
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.3 to 2024.3.4

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662385/IntelliJ-IDEA-2024.3.4-243.25659.39-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.3.4 is out with the following improvements: 
<ul>
 <li>The IDE no longer incorrectly reports missing required keys in gitlab-ci.yml. [<a href="https://youtrack.jetbrains.com/issue/IJPL-171698">IJPL-171698</a>]</li>
 <li>The IDE no longer adds unnecessary spaces around slashes when copying text from the quick documentation. [<a href="https://youtrack.jetbrains.com/issue/IJPL-149061">IJPL-149061</a>]</li>
 <li>Plugin updates are once again detected and processed correctly. [<a href="https://youtrack.jetbrains.com/issue/IJPL-175450">IJPL-175450</a>]</li>
 <li>AWS providers in Terraform are now properly recognized, with correct code completion. [<a href="https://youtrack.jetbrains.com/issue/IJPL-164351">IJPL-164351</a>]</li>
 <li>Several issues related to the Kafka plugin have been resolved. [<a href="https://youtrack.jetbrains.com/issue/IJPL-176005">IJPL-176005</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-159726">IJPL-159726</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-172466">IJPL-172466</a>, <a href="https://youtrack.jetbrains.com/issue/IJPL-172433">IJPL-172433</a>]</li>
</ul> Get more details in our <a href="https://blog.jetbrains.com/idea/2025/02/intellij-idea-2024-3-4/">blog post</a>.
    