### PR TITLE
Upgrading IntelliJ from 2025.2.2 to 2025.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2025.2.2 to 2025.2.3
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/environment-variable-settin
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 5.1.2
+pluginVersion = 5.1.3
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 252.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2025.2.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.2.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -33,7 +33,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2025.2.2
+platformVersion = 2025.2.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2025.2.2 to 2025.2.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662511/IntelliJ-IDEA-2025.2.3-252.26830.84-build-Release-Notes

# What's New?
IntelliJ IDEA 2025.2.3 is out! This release includes the following improvements: 
<ul>
 <li>Jira Task Server integration now works as before when fetching tasks. [<a href="https://youtrack.jetbrains.com/issue/IJPL-208931">IJPL-208931</a>]</li>
 <li>Breakpoints now work as expected in the Services view when the ClassicUI plugin is enabled. [<a href="https://youtrack.jetbrains.com/issue/IDEA-378292">IDEA-378292</a>]</li>
 <li>It's once again possible to open multiple files from the <i>Find Usages</i> dialog. [<a href="https://youtrack.jetbrains.com/issue/IJPL-201422">IJPL-201422</a>]</li>
</ul> Get more details from our <a href="https://blog.jetbrains.com/idea/2025/10/intellij-idea-2025-2-3/">blog post</a>.
    