### PR TITLE
Upgrading IntelliJ from 2026.2.0.1 to 2026.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## [6.0.2] - 2026-05-16
 
 ### Changed
+- Upgrading IntelliJ from 2026.2.0.1 to 2026.2.1
 - Upgrading IntelliJ from 2026.2 to 2026.2.0.1
 - Upgrading IntelliJ from 2026.1.4 to 2026.2
 - Upgrading IntelliJ from 2026.1.3 to 2026.1.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/environment-variable-settin
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 6.1.1
+pluginVersion = 6.1.2
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 262.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2026.2.0.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.2.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 pluginVerifierExcludeFailureLevels =
 # Mute Plugin Problems -> https://github.com/JetBrains/intellij-plugin-verifier?tab=readme-ov-file#check-plugin
@@ -31,7 +31,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2026.2.0.1
+platformVersion = 2026.2.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.2.0.1 to 2026.2.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662729

# What's New?
<p>IntelliJ IDEA 2026.2.1 is out with the following improvements:</p>
<ul>
 <li>Markdown shell scripts now execute in the correct order. [<a href="https://youtrack.jetbrains.com/issue/IJPL-92206/">IJPL-92206</a>]</li>
 <li>Undo now works correctly after applying <em>Optimize imports on the fly</em>. [<a href="https://youtrack.jetbrains.com/issue/IDEA-285011/">IDEA-285011</a>]</li>
 <li>Dragging a terminal tab after using the <em>Move to Editor</em> action no longer restarts the terminal session. [<a href="https://youtrack.jetbrains.com/issue/IJPL-165734/Terminal-restarts-when-dragged-after-Move-to-Editor">IJPL-165734</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2026/08/intellij-idea-2026-2-1/">blog post</a>.</p>
    